### PR TITLE
Fix start/end time autofill

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,7 +555,6 @@
       startEl=document.getElementById('startTime'),endEl=document.getElementById('endTime');
     function estimateTimes(){
       const mins=Number(minEl.value||0);if(!mins){return;}
-      if(dateEl.value!==todayStr()){return;}
       const end=new Date(),start=new Date(end.getTime()-mins*60000);
       const fmt=d=>`${pad(d.getHours())}:${pad(d.getMinutes())}`;
       startEl.value=fmt(start);endEl.value=fmt(end);


### PR DESCRIPTION
## Summary
- always autofill start and end times when minutes are entered

## Testing
- `node -c /tmp/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68857e33cdac8328abb7a8303ad90515