### PR TITLE
Fix cat list button width for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,9 +306,18 @@
       display:flex;align-items:center;justify-content:center;
       flex:1 1 auto;white-space:nowrap;
     }
-    .cat-list-row .tab-btn,.cat-list-row .tab-btn.danger {
-      font-size:12px;padding:0 8px;border-radius:8px;min-width:0;height:24px;
-      display:flex;align-items:center;justify-content:center;flex-shrink:0;
+    .cat-list-row .tab-btn,
+    .cat-list-row .tab-btn.danger {
+      font-size:12px;
+      padding:0 8px;
+      border-radius:8px;
+      min-width:0;
+      height:24px;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      flex-shrink:0;
+      width:auto;
     }
 
   </style>


### PR DESCRIPTION
## Summary
- ensure category list buttons don't stretch full width on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68858222c7048328a9d1dc76bf1774ff