### PR TITLE
Format numbers with thousand separators

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,6 +499,7 @@
     const save=(k,v)=>localStorage.setItem(k,JSON.stringify(v));
     let entries=load(KEYS.entries,[]),categories=load(KEYS.cats,['IELTSリーディング','単語','スピーキング','リスニング','文法','ライティング']),goals=load(KEYS.goals,[]);
     const latestGoal = ()=> goals.length ? goals[goals.length-1] : null;
+    const fmt=(n,d)=>Number(n).toLocaleString('en-US',d!==undefined?{minimumFractionDigits:d,maximumFractionDigits:d}:{});
 
     // --- タブ制御
     const tabBtns=[...document.querySelectorAll('.tab-btn[data-tab]')];
@@ -534,7 +535,7 @@
           .filter(x=>{const d=parseDateStr(x.date);return d>=s&&d<=e;})
           .reduce((a,b)=>a+b.minutes,0);
       }
-      const totalH = (totalMin/60).toFixed(1);
+      const totalH = fmt(totalMin/60,1);
       // 記録開始日数:目標開始基準
       let startDate = entries.map(e=>e.date).sort()[0];
       let days = 1, goalPeriod = "";
@@ -556,20 +557,20 @@
           const estDays = Math.ceil(remain/avg);
           const d = new Date();
           d.setDate(d.getDate()+estDays);
-          predict = `${estDays}日後（${d.getFullYear()}/${pad(d.getMonth()+1)}/${pad(d.getDate())}）`;
+          predict = `${fmt(estDays)}日後（${d.getFullYear()}/${pad(d.getMonth()+1)}/${pad(d.getDate())}）`;
         } else if (totalMin >= tgt && tgt > 0) {
           predict = '達成済み';
         }
       }
       wrap.innerHTML = `
-        <div class="summary-kpi">合計 <span style="font-weight:700">${totalH}</span> h  (${totalMin.toLocaleString()} m)</div>
+        <div class="summary-kpi">合計 <span style="font-weight:700">${totalH}</span> h  (${fmt(totalMin)} m)</div>
         <div class="summary-progress-bar"><div class="summary-progress-bar-inner" id="mainProgressBar"></div></div>
         <div class="summary-list">
           <div>
-            記録開始から <span style="font-weight:600">${days}</span> 日間
+            記録開始から <span style="font-weight:600">${fmt(days)}</span> 日間
             ${goalPeriod}
           </div>
-          <div>目標：${tgt?tgt/60+'h':'—'}（達成率${pct||0}%）</div>
+          <div>目標：${tgt?fmt(tgt/60,1)+'h':'—'}（達成率${fmt(pct||0)}%）</div>
           <div>目標到達予測：${predict||'—'}</div>
         </div>
       `;
@@ -627,7 +628,7 @@
       monthGrid.innerHTML=blanks+Array.from({length:lastDate},(_,i)=>{
         const d=i+1,key=`${y}-${pad(m+1)}-${pad(d)}`,sum=totals[key]||0;
         const level=sum===0?0:Math.min(4,Math.ceil((sum/(monthMax||1))*4));const isToday=key===todayStr();
-        return `<div class="day lvl${level} ${isToday?'today':''}" data-date="${key}"><div class="num">${d}</div><div class="mins">${sum?sum+'m':''}</div></div>`;
+        return `<div class="day lvl${level} ${isToday?'today':''}" data-date="${key}"><div class="num">${d}</div><div class="mins">${sum?fmt(sum)+'m':''}</div></div>`;
       }).join('');
       dayDetails.innerHTML='';
     }
@@ -637,12 +638,12 @@
       dayDetails.innerHTML=`
         <div class="day-detail-wrap">
           <div class="day-detail-title">${d}</div>
-          <div class="day-detail-total">合計 <strong>${(total/60).toFixed(1)}</strong>h (${total}m)</div>
+          <div class="day-detail-total">合計 <strong>${fmt(total/60,1)}</strong>h (${fmt(total)}m)</div>
           <div class="day-detail-list">
             ${list.length?list.map(e=>`
               <div class="rec-row">
                 <span class="chip muted">${e.category}</span>
-                <span style="font-size:13px;color:var(--muted)">${e.minutes}m${(e.startTime&&e.endTime)?`（${e.startTime}～${e.endTime}）`:''}</span>
+                <span style="font-size:13px;color:var(--muted)">${fmt(e.minutes)}m${(e.startTime&&e.endTime)?`（${e.startTime}～${e.endTime}）`:''}</span>
                 <button class="del-btn" data-del="${e.id}">×</button>
               </div>
             `).join(''):`<div class="muted" style="padding:10px 0 0 4px;">記録なし</div>`}
@@ -765,12 +766,12 @@
         const stats=goalStats(g);
         accum=stats.accum;target=stats.target;pct=stats.pct;
         const daysLeft=Math.max(0,Math.ceil((parseDateStr(g.end)-new Date())/86400000));
-        left=`終了まで残り ${daysLeft} 日`;
+        left=`終了まで残り ${fmt(daysLeft)} 日`;
       }
       goalBar.style.width=pct+'%';
-      goalAccum.textContent=g?`${(accum/60).toFixed(1)}h (${accum}m)`:'—';
-      goalTarget.textContent=g?`${(target/60).toFixed(1)}h (${target}m)`:'—';
-      goalPct.textContent=g?`${pct}%`:'—';
+      goalAccum.textContent=g?`${fmt(accum/60,1)}h (${fmt(accum)}m)`:'—';
+      goalTarget.textContent=g?`${fmt(target/60,1)}h (${fmt(target)}m)`:'—';
+      goalPct.textContent=g?`${fmt(pct)}%`:'—';
       goalDaysLeft.textContent=g?left:'';
     }
     // 目標履歴
@@ -782,9 +783,9 @@
           return `<div class="goal-hist-item">
             <div class="goal-hist-period">${g.start}〜${g.end}</div>
             <div class="goal-hist-kpis">
-              <span class="gh-kpi">累計: <b>${(stats.accum/60).toFixed(1)}h</b></span>
-              <span class="gh-kpi">目標: <b>${g.targetMin/60}h</b></span>
-              <span class="gh-kpi">達成率: <b>${stats.pct}%</b></span>
+              <span class="gh-kpi">累計: <b>${fmt(stats.accum/60,1)}h</b></span>
+              <span class="gh-kpi">目標: <b>${fmt(g.targetMin/60,1)}h</b></span>
+              <span class="gh-kpi">達成率: <b>${fmt(stats.pct)}%</b></span>
             </div>
             <button class="goal-hist-del-btn" data-goaldel="${goals.length-2-i}">×</button>
           </div>`;


### PR DESCRIPTION
## Summary
- add helper `fmt` for number formatting
- show formatted totals, goal values and statistics with commas
- apply formatting to calendar totals and history records

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885c35f154c8328ab317dddd5d3cd3f