### PR TITLE
Fix day detail stay open after delete

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,6 +623,7 @@
       yearTitle=document.getElementById('yearTitle'),
       prevYearBtn=document.getElementById('prevYear'),
       nextYearBtn=document.getElementById('nextYear');
+    let activeDayDetail=null;
     const DOW=['月','火','水','木','金','土','日'];
     let currentYM={y:new Date().getFullYear(),m:new Date().getMonth()};
     let currentYear=currentYM.y;
@@ -639,8 +640,8 @@
       }).join('');
       dayDetails.innerHTML='';
     }
-    monthGrid.addEventListener('click',e=>{
-      const d=e.target.closest('.day')?.dataset?.date;if(!d)return;
+    function renderDayDetails(d){
+      activeDayDetail=d;
       const list=entries.filter(x=>x.date===d).sort((a,b)=>b.createdAt-a.createdAt),total=list.reduce((a,b)=>a+b.minutes,0);
       dayDetails.innerHTML=`
         <div class="day-detail-wrap">
@@ -657,10 +658,21 @@
           </div>
         </div>
       `;
+    }
+    monthGrid.addEventListener('click',e=>{
+      const d=e.target.closest('.day')?.dataset?.date;if(!d)return;
+      renderDayDetails(d);
     });
     dayDetails.addEventListener('click',e=>{
       const id=e.target?.dataset?.del;if(!id)return;
-      entries=entries.filter(x=>String(x.id)!==String(id));save(KEYS.entries,entries);toast('削除しました');renderAll();
+      entries=entries.filter(x=>String(x.id)!==String(id));
+      save(KEYS.entries,entries);
+      toast('削除しました');
+      renderSummary();
+      renderMonth();
+      renderGoal();
+      renderGoalHistory();
+      if(activeDayDetail) renderDayDetails(activeDayDetail);
     });
 
     prevMonthBtn.addEventListener('click',()=>{if(currentYM.m===0){currentYM.y--;currentYM.m=11;}else currentYM.m--;renderMonth();});


### PR DESCRIPTION
## Summary
- keep the selected day's detail open when deleting a study record
- re-render the day's detail only and update summary/monthly view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885d40d337083289cb9fe0bbdd77d2b