### PR TITLE
Fix month title visibility after year view

### DIFF
--- a/index.html
+++ b/index.html
@@ -754,6 +754,7 @@
       dayDetails.style.display='';
       prevMonthBtn.style.display='';
       nextMonthBtn.style.display='';
+      monthTitle.style.display='';
       prevYearBtn.style.display='none';
       nextYearBtn.style.display='none';
       yearTitle.style.display='none';


### PR DESCRIPTION
## Summary
- ensure month title shows when selecting a month from year view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6885d62971988328a369eecfec46e06f