### PR TITLE
Update calendar views on entry changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -779,6 +779,7 @@
       renderSummary();
       renderWeek();
       renderMonth();
+      renderYear();
       renderGoal();
       renderActiveGoals();
       renderGoalHistory();
@@ -1068,7 +1069,17 @@
     });
 
     // --- 全体レンダリング
-    function renderAll(){renderCategorySelect();renderSummary();renderWeek();renderMonth();renderGoal();renderActiveGoals();renderGoalHistory();renderCats();}
+    function renderAll(){
+      renderCategorySelect();
+      renderSummary();
+      renderWeek();
+      renderMonth();
+      renderYear();
+      renderGoal();
+      renderActiveGoals();
+      renderGoalHistory();
+      renderCats();
+    }
     function init(){dateEl.value=todayStr();estimateTimes();renderAll();}
     init();
 


### PR DESCRIPTION
## Summary
- refresh year view whenever entries change
- show updates immediately in week and year calendars

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886338584288328b28c224c92d28c25