### PR TITLE
Fix week view refresh after adding entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -710,8 +710,13 @@
       e.preventDefault();
       const minutes=Number(minEl.value),cat=catSel.value,st=startEl.value,endt=endEl.value;
       if(!minutes||minutes<=0||!cat)return;
-      entries.push({id:Date.now().toString(36),date:dateEl.value||todayStr(),minutes,category:cat,createdAt:Date.now(),startTime:st,endTime:endt});
-      save(KEYS.entries,entries);minEl.value='';estimateTimes();toast();renderAll();
+      const dStr = dateEl.value||todayStr();
+      entries.push({id:Date.now().toString(36),date:dStr,minutes,category:cat,createdAt:Date.now(),startTime:st,endTime:endt});
+      save(KEYS.entries,entries);minEl.value='';estimateTimes();toast();
+      if(calendarViewSel.value==='week'){
+        currentWeekStart=startOfWeek(parseDateStr(dStr));
+      }
+      renderAll();
       setCalendarView(calendarViewSel.value);
     });
 


### PR DESCRIPTION
## Summary
- update `currentWeekStart` when adding a record while the week calendar is visible
- re-render the week view immediately

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68863c5a760483288aac8b40685d9750