### PR TITLE
Fix deletion not reflected on calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -788,12 +788,12 @@
       toast('削除しました');
       renderSummary();
       renderWeek();
-      renderMonth();
       renderYear();
       renderGoal();
       renderActiveGoals();
       renderGoalHistory();
       if(activeDayDetail) renderDayDetails(activeDayDetail);
+      renderMonth();
       setCalendarView(calendarViewSel.value);
       const btn = document.elementFromPoint(clientX, clientY);
       if(row) row.remove();


### PR DESCRIPTION
## Summary
- ensure deleting a record re-renders month view after day details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886c23bbab88328bbf5845261406636