### PR TITLE
Fix date field layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@
     .week-heatmap .hour-label{display:flex;align-items:center;justify-content:center;font-size:10px;color:var(--muted)}
 
     /* フォームまわり（時刻入力→時間選択 & 余白調整） */
-    .form-row-flex {display:flex;gap:12px;align-items:flex-end;margin-bottom:4px;}
+    .form-row-flex {display:flex;gap:12px;align-items:flex-end;margin-bottom:4px;flex-wrap:wrap;}
     @media (max-width:600px){.form-row-flex{flex-direction:column;align-items:stretch;gap:4px;}}
     .input-block {flex:1;}
     .time-input-row {display:flex;gap:8px;align-items:center;margin-top:6px;margin-bottom:14px;} /* ← 余白追加 */
@@ -213,7 +213,7 @@
     .minutes-block{flex:0 0 140px;}
     .minutes-block input{max-width:100%;}
     @media (max-width:600px){.minutes-block{flex-basis:auto;}}
-    .date-block{flex:0 0 160px;}
+    .date-block{flex:0 1 160px;}
     @media (max-width:600px){.date-block{flex-basis:auto;}}
   </style>
 </head>


### PR DESCRIPTION
## Summary
- allow the date input container to shrink so it no longer overflows
- wrap the first row of the record form when space is limited

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68887dfb9f2c8328836255fa882f7b69