### PR TITLE
Adjust spacing between minutes and time fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,9 +197,9 @@
     select{height:48px;}
     .minutes-block{flex:0 0 140px;}
     .date-block{flex:1;min-width:160px;}
-    .form-row-flex{display:flex;gap:12px;align-items:flex-end;margin-bottom:4px;flex-wrap:wrap;}
+    .form-row-flex{display:flex;gap:12px;align-items:flex-end;margin-bottom:0;flex-wrap:wrap;}
     @media (max-width:600px){.form-row-flex{flex-direction:column;align-items:stretch;gap:4px;}}
-    .time-input-row{display:flex;gap:8px;align-items:center;margin-top:2px;margin-bottom:8px;}
+    .time-input-row{display:flex;gap:8px;align-items:center;margin-top:0;margin-bottom:8px;}
     .time-fields{display:flex;gap:8px;flex:1 1 0;min-width:0;align-items:center;}
 
     /* トースト */


### PR DESCRIPTION
## Summary
- tweak study record layout to remove gap between the "勉強時間 (m)" field and the start/end time inputs

## Testing
- `npm test` *(fails: command not found)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6888cb69a040832896dce469019d8183