### PR TITLE
Fix minutes block spacing on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,10 @@
     .minutes-block{flex:0 0 140px;}
     .date-block{flex:1;min-width:160px;}
     .form-row-flex{display:flex;gap:12px;align-items:flex-end;margin-bottom:0;flex-wrap:wrap;}
-    @media (max-width:600px){.form-row-flex{flex-direction:column;align-items:stretch;gap:4px;}}
+    @media (max-width:600px){
+      .form-row-flex{flex-direction:column;align-items:stretch;gap:4px;}
+      .minutes-block{flex:1 1 0;}
+    }
     .time-input-row{display:flex;gap:8px;align-items:center;margin-top:0;margin-bottom:8px;}
     .time-fields{display:flex;gap:8px;flex:1 1 0;min-width:0;align-items:center;}
 


### PR DESCRIPTION
## Summary
- fix layout gap between 勉強時間 and 開始・終了時刻 on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688987aaa344832898a13a1ad3886a95