### PR TITLE
Fix mobile spacing in record form

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
     select{height:48px;}
     .minutes-block{flex:0 0 140px;}
     .date-block{flex:1;min-width:160px;}
-    .form-row-flex{display:flex;gap:12px;align-items:flex-end;margin-bottom:0;flex-wrap:wrap;}
+    .form-row-flex{display:flex;gap:12px;align-items:flex-end;margin-bottom:8px;flex-wrap:wrap;}
     @media (max-width:600px){
       .form-row-flex{flex-direction:column;align-items:stretch;gap:4px;}
       .minutes-block{flex:1 1 0;}


### PR DESCRIPTION
## Summary
- fix margin below record form row so there is spacing between study time and start/end time fields on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889d4371f308328997277e4b92cf618