### PR TITLE
Fix goal tabs visibility on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,6 +52,8 @@
     /* PC向けタブ */
     .tabs{display:flex;gap:8px;margin-top:8px;flex-wrap:wrap}
     @media (max-width:640px){.tabs{display:none}}
+    /* summaryGoalTabs should remain visible on mobile */
+    @media (max-width:640px){#summaryGoalTabs{display:flex}}
     @media (min-width:641px){#menuBtn,#menuPanel,#menuBackdrop{display:none!important}}
     .tab-btn{
       border:1px solid rgba(255,255,255,.12);background:var(--card);color:var(--text);


### PR DESCRIPTION
## Summary
- keep summary goal tabs visible on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a09ba6838832893ffdc487ac52dfa