### PR TITLE
Show date range for longest study streak

### DIFF
--- a/index.html
+++ b/index.html
@@ -597,21 +597,29 @@
         cursor.setDate(cursor.getDate()-1);
       }
       let longestStreak = 0;
+      let longestStreakRange = null;
       if(studyDaySet.size){
         const orderedDays = Array.from(studyDaySet).map(parseDateStr).sort((a,b)=>a-b);
         let run = 0;
         let prev = null;
+        let runStart = null;
         const DAY_MS = 86400000;
         orderedDays.forEach(d=>{
           if(prev && (d - prev === DAY_MS)){
             run += 1;
           }else{
             run = 1;
+            runStart = d;
           }
-          if(run>longestStreak) longestStreak = run;
+          if(run>longestStreak){
+            longestStreak = run;
+            const startDate = runStart || d;
+            longestStreakRange = { start: new Date(startDate), end: new Date(d) };
+          }
           prev = d;
         });
       }
+      const longestStreakPeriod = longestStreakRange ? `（${dateToStr(longestStreakRange.start).replace(/-/g,'/')}〜${dateToStr(longestStreakRange.end).replace(/-/g,'/')}）` : '';
 
       const thisWeekStart = startOfWeek(today);
       const thisMonthStart = new Date(today.getFullYear(), today.getMonth(), 1);
@@ -675,7 +683,7 @@
            <div>目標：${tgt?fmt(tgt/60,1)+'h':'—'}（達成率${fmt(pct||0)}%）</div>
            <div>目標到達予測：${predict||'—'}</div>
            <div>現在の連続勉強日数：<span style="font-weight:600">${fmt(currentStreak)}</span>日</div>
-           <div>最長連続勉強日数：<span style="font-weight:600">${fmt(longestStreak)}</span>日</div>
+          <div>最長連続勉強日数：<span style="font-weight:600">${fmt(longestStreak)}</span>日${longestStreakPeriod}</div>
          </div>
          <div class="summary-list" style="margin-top:4px;">
            <div class="summary-range">


### PR DESCRIPTION
## Summary
- track the start and end dates of the longest consecutive study streak
- display the longest streak period next to the streak length in the summary card

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbda647ad88328b69bb6d947ddec03